### PR TITLE
Disable arch native for `wasm32-unknown-emscripten` target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,7 +368,7 @@ macro(xvega_set_common_options target_name)
             # PowerPC does not support -march
             if (CMAKE_SYSTEM_PROCESSOR MATCHES "ppc|powerpc")
                 target_compile_options(${target_name} PUBLIC -mtune=native)
-            else ()
+            elseif (NOT EMSCRIPTEN)
                 target_compile_options(${target_name} PUBLIC -march=native)
             endif ()
         endif ()


### PR DESCRIPTION
The `XVEGA_DISABLE_ARCH_NATIVE` flag no longer exists. When building with emscripten, it fails because it does not support `-march=native` (See https://github.com/emscripten-forge/recipes/pull/1112).